### PR TITLE
Bootstrap version problem when try to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "@popperjs/core": "^2.5.4",
         "aos": "^2.3.4",
-        "bootstrap": "^5.0.0-beta3",
+        "bootstrap": "5.0.0-beta3",
         "choices.js": "^9.0.1",
         "medium-zoom": "^1.0.6",
         "nouislider": "^14.6.3",


### PR DESCRIPTION
First thing first, thank for this pretty template. After pulling this repo and building it in my local computer i see lots of errors in my terminal like following;
````
ERROR in ./src/assets/scss/theme.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Undefined variable.
    ╷
102 │         null: var(--#{$prefix}border-width) var(--#{$prefix}border-style) var(--#{$prefix}border-color),
````
After running `npm update` command and changing bootstrap version in `package.json` from 

````
        "bootstrap": "^5.0.0-beta3",
```` 
to
````
        "bootstrap": "5.0.0-beta3",
````
solve my issues. I guess it should be edited in main repo.